### PR TITLE
add callback to fs.chmod

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ module.exports = function (port, config) {
 		server.on('listening', function() {
 			// set permissions
 			if (config.debug) console.log('Changing socket permissions');
-			return fs.chmod(port, '0777');
+			return fs.chmod(port, 0o777);
 		});
 
 		// double-check EADDRINUSE

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ module.exports = function (port, config) {
 		server.on('listening', function() {
 			// set permissions
 			if (config.debug) console.log('Changing socket permissions');
-			return fs.chmod(port, 0o777);
+			return fs.chmod(port, 0o777, function(){});
 		});
 
 		// double-check EADDRINUSE

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cptn",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A webserver that does something with POSTed JSON. Indended for use with GitLab webhooks.",
   "main": "index.js",
   "scripts": {
@@ -18,6 +18,7 @@
     "email": "p@philippbock.de",
     "url": "http://philippbock.de"
   },
+  "contributors": ["Sebastian Vollnhals <node@yetzt.me>"],
   "repository": "pbock/cptn",
   "license": "MIT"
 }


### PR DESCRIPTION
for some reason the asynchronous `fs.chmod` actually requires a callback function. therefore an empty callback function is provided.